### PR TITLE
Get plugin to work again on Blender versions starting from 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+thicket.db
+thicket.log

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Thicket provides a visual plant selection gallery and options to configure the p
 
 ## Install
 * Download and install the prerequisites
-  * [Blender](http://www.blender.org/) 2.80 ~~or later~~ through 3.0.1. Laubwerk 1.0.43 supports up to Python 3.9, Blender 3.1 switched to Python 3.10. Until Laubwerk adds Python 3.10 support, Blender 3.0.1 is the latest version Thicket can support.
-  * Laubwerk Python SDK 1.0.33 or later, provided by all Laubwerk Plant Kits, including the [Plants Kit Freebie](http://www.laubwerk.com/store/plants-kit-freebie).
+  * [Blender](http://www.blender.org/) 2.80 or later
+  * Laubwerk Python SDK 1.0.49 or later, provided by all Laubwerk Plant Kits, including the [Plants Kit Freebie](http://www.laubwerk.com/store/plants-kit-freebie).
     * Choose the "Custom" installation method and ensure the "Python Extension" component is checked.
 * Installation options
   * From a release Zip file (most users)

--- a/__init__.py
+++ b/__init__.py
@@ -371,7 +371,8 @@ def select_plant(filepath, defaults=False):
     old_qual = tp.qualifier
 
     if defaults:
-        for key in tp.keys():
+        keys = list(tp.keys())
+        for key in keys:
             tp.pop(key)
 
     tp.name = plant.name

--- a/__init__.py
+++ b/__init__.py
@@ -430,8 +430,8 @@ class ThicketPropGroup(PropertyGroup):
     def import_lbw(self, original=None):
         filepath = db.get_model(name=self.name).filepath
         tp = self
-        variant = self.variant
         mesh_args = {}
+        mesh_args["variant"] = self.variant
         mesh_args["season"] = self.season
 
         if original:
@@ -445,9 +445,9 @@ class ThicketPropGroup(PropertyGroup):
                 filepath = db.get_model(name=self.batch_name).filepath
             if not self.batch_use_lod:
                 tp = orig_tp
-            variant = self.batch_variant
-            if variant == 'UNCHANGED':
-                variant = orig_tp.variant
+            mesh_args["variant"] = self.batch_variant
+            if self.batch_variant == 'UNCHANGED':
+                mesh_args["variant"] = orig_tp.variant
             mesh_args["season"] = self.batch_season
             if self.batch_season == 'UNCHANGED':
                 mesh_args["season"] = orig_tp.season
@@ -480,7 +480,7 @@ class ThicketPropGroup(PropertyGroup):
                 if self.render_lod != orig_tp.render_lod:
                     render_obj = orig_template.objects[0]
 
-        model_obj = thicket_lbw.import_lbw(filepath, variant, tp.viewport_lod, tp.render_lod, mesh_args,
+        model_obj = thicket_lbw.import_lbw(filepath, tp.viewport_lod, tp.render_lod, mesh_args,
                                            viewport_obj, render_obj)
         self.copy_to(model_obj.instance_collection.thicket)
         model_obj.instance_collection.thicket.magic = THICKET_GUID
@@ -557,7 +557,7 @@ class ThicketPropGroup(PropertyGroup):
     lod_min_thick: FloatProperty(name="Min Branch Thickness", description="Min thickness of trunk or branches",
                                  default=0.1, min=0.1, max=10000.0, step=1.0)
     lod_subdiv: IntProperty(name="Max Subdivisions", description="How round the trunk and branches appear",
-                            default=3, min=0, max=5, step=1)
+                            default=1, min=0, max=5, step=1)
     leaf_amount: FloatProperty(name="Leaf Amount", description="How many leaves used for leaf density "
                                "(smaller number means larger leaves)",
                                default=100.0, min=0.01, max=100.0, subtype='PERCENTAGE')

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -47,7 +47,7 @@ def md5sum(filename):
     return md5.hexdigest()
 
 
-class DBQualifier:
+class DBSeason:
     def __init__(self, db, name):
         self.name = name
         self.label = db.get_label(name)
@@ -57,19 +57,19 @@ class DBVariant:
     def __init__(self, db, name, v_rec, plant_preview):
         self.name = name
         self.label = db.get_label(self.name)
-        self.qualifiers = [DBQualifier(db, q) for q in v_rec["qualifiers"]]
-        self._default_qualifier = DBQualifier(db, v_rec["default_qualifier"])
+        self.seasons = [DBSeason(db, s) for s in v_rec["seasons"]]
+        self._default_season = DBSeason(db, v_rec["default_season"])
         self.preview = v_rec["preview"]
         if self.preview == "":
             self.preview = plant_preview
 
-    def get_qualifier(self, name=None):
-        """ Return the requested qualifier or the default qualifier if None or not found """
+    def get_season(self, name=None):
+        """ Return the requested season or the default season if None or not found """
         if name is not None:
-            for q in self.qualifiers:
-                if q.name == name:
-                    return q
-        return self._default_qualifier
+            for s in self.seasons:
+                if s.name == name:
+                    return s
+        return self._default_season
 
 
 class DBPlant:
@@ -261,8 +261,8 @@ class ThicketDB:
             print("\tdefault_variant: %s (%s)" % (v.name, v.label))
             print("\tvariants:")
             for v in plant.variants:
-                print("\t\t%s (%s) %s" % (v.name, v.get_qualifier().label,
-                                          [q.name for q in v.qualifiers]))
+                print("\t\t%s (%s) %s" % (v.name, v.get_season().label,
+                                          [s.name for s in v.seasons]))
 
     # Class methods
     def parse_plant(filepath):
@@ -293,20 +293,20 @@ class ThicketDB:
         variants = {}
         i = 0
         seasons = []
-        q_labels = {}
-        for q in p.params[0]['enum']['options']:
-            seasons.append(q['name'])
-            q_labels[q['name']] = {}
-            for q_lang in q['labels']:
-                q_labels[q['name']][q_lang['lang']] = q_lang['text']
+        s_labels = {}
+        for s in p.params[0]['enum']['options']:
+            seasons.append(s['name'])
+            s_labels[s['name']] = {}
+            for s_lang in s['labels']:
+                s_labels[s['name']][s_lang['lang']] = s_lang['text']
         default_season = p.params[0]['enum']['default']
 
         for v in p.variants:
             v_rec = {}
-            labels.update(q_labels)
+            labels.update(s_labels)
             v_rec["index"] = i
-            v_rec["qualifiers"] = seasons
-            v_rec["default_qualifier"] = seasons[default_season]
+            v_rec["seasons"] = seasons
+            v_rec["default_season"] = seasons[default_season]
             preview_path = Path(filepath).parent.absolute() / "models" / (preview_stem + "_" + v.name + ".png")
             if not preview_path.is_file():
                 logger.warning("Preview not found: %s" % preview_path)

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -274,7 +274,7 @@ class ThicketDB:
         plant["filepath"] = filepath
         plant["md5"] = md5sum(filepath)
         plant["default_model"] = p.default_model.name
-        preview_stem = p.name.replace(" ", "_").replace(".", "")
+        preview_stem = p.plant_meta["botanical_name"].replace(" ", "_").replace(".", "")
         preview_path = Path(filepath).parent.absolute() / (preview_stem + ".png")
         if not preview_path.is_file():
             logger.warning("Preview not found: %s" % preview_path)

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -54,14 +54,14 @@ class DBSeason:
 
 
 class DBVariant:
-    def __init__(self, db, name, v_rec, plant_preview):
+    def __init__(self, db, name, v_rec, model_preview):
         self.name = name
         self.label = db.get_label(self.name)
         self.seasons = [DBSeason(db, s) for s in v_rec["seasons"]]
         self._default_season = DBSeason(db, v_rec["default_season"])
         self.preview = v_rec["preview"]
         if self.preview == "":
-            self.preview = plant_preview
+            self.preview = model_preview
 
     def get_season(self, name=None):
         """ Return the requested season or the default season if None or not found """
@@ -72,17 +72,17 @@ class DBVariant:
         return self._default_season
 
 
-class DBPlant:
+class DBModel:
     def __init__(self, db, name):
         self.name = name
-        p_rec = db._db["plants"][name]
-        self.md5 = p_rec["md5"]
-        self.filepath = p_rec["filepath"]
+        m_rec = db._db["models"][name]
+        self.md5 = m_rec["md5"]
+        self.filepath = m_rec["filepath"]
         self.label = db.get_label(self.name)
-        preview = p_rec["preview"]
-        self.variants = [DBVariant(db, v, p_rec["variants"][v], preview) for v in p_rec["variants"]]
-        def_v = p_rec["default_variant"]
-        self._default_variant = DBVariant(db, def_v, p_rec["variants"][def_v], preview)
+        preview = m_rec["preview"]
+        self.variants = [DBVariant(db, v, m_rec["variants"][v], preview) for v in m_rec["variants"]]
+        def_v = m_rec["default_variant"]
+        self._default_variant = DBVariant(db, def_v, m_rec["variants"][def_v], preview)
         self.preview = preview
 
     def get_variant(self, name=None):
@@ -99,9 +99,9 @@ class DBIter:
         self._items = []
         self._index = 0
 
-        for name in db._db["plants"]:
-            self._items.append(DBPlant(db, name))
-        self._items.sort(key=lambda plant: plant.name)
+        for name in db._db["models"]:
+            self._items.append(DBModel(db, name))
+        self._items.sort(key=lambda model: model.name)
 
     def __next__(self):
         if self._index < len(self._items):
@@ -146,7 +146,7 @@ class ThicketDB:
         self._db = {}
         self._db["info"] = {}
         self._db["labels"] = {}
-        self._db["plants"] = {}
+        self._db["models"] = {}
 
         self._db["info"]["sdk_version"] = lbw.version
         self._db["info"]["sdk_major"] = lbw.version_info.major
@@ -164,7 +164,7 @@ class ThicketDB:
         print("\tmajor: %s" % info["sdk_major"])
         print("\tminor: %s" % info["sdk_minor"])
         print("\tmicro: %s" % info["sdk_micro"])
-        print("Loaded %d plants:" % self.plant_count())
+        print("Loaded %d models:" % self.model_count())
 
     def update_labels(self, labels):
         self._db["labels"].update(labels)
@@ -184,35 +184,35 @@ class ThicketDB:
         except KeyError:
             return key
 
-    def get_plant(self, filepath=None, name=None):
+    def get_model(self, filepath=None, name=None):
         if name:
-            if name not in self._db["plants"]:
+            if name not in self._db["models"]:
                 name = None
 
         if name is None and filepath:
-            for n in self._db["plants"]:
-                if self._db["plants"][n]["filepath"] == filepath:
+            for n in self._db["models"]:
+                if self._db["models"][n]["filepath"] == filepath:
                     name = n
 
         if name:
-            return DBPlant(self, name)
+            return DBModel(self, name)
 
         return None
 
-    def add_plant(self, filepath):
-        p_rec = ThicketDB.parse_plant(filepath)
-        self._db["plants"][p_rec["name"]] = p_rec["plant"]
-        self.update_labels(p_rec["labels"])
+    def add_model(self, filepath):
+        m_rec = ThicketDB.parse_model(filepath)
+        self._db["models"][m_rec["name"]] = m_rec["model"]
+        self.update_labels(m_rec["labels"])
 
-    def plant_count(self):
-        return len(self._db["plants"])
+    def model_count(self):
+        return len(self._db["models"])
 
-    def build(self, plants_dir, sdk_path):
+    def build(self, models_dir, sdk_path):
         self.initialize()
 
         # FIXME: .gz is optional
-        plant_files = glob.glob(plants_dir + "/*/*.lbw.gz")
-        num_plants = len(plant_files)
+        model_files = glob.glob(models_dir + "/*/*.lbw.gz")
+        num_models = len(model_files)
 
         num_jobs = os.cpu_count()
         if not num_jobs:
@@ -220,13 +220,13 @@ class ThicketDB:
         jobs = deque()
 
         log_level = logging.getLevelName(logger.level)
-        logger.info("Parsing %d plants using %d parallel jobs" % (num_plants, num_jobs))
-        while len(plant_files) > 0 or len(jobs) > 0:
+        logger.info("Parsing %d models using %d parallel jobs" % (num_models, num_jobs))
+        while len(model_files) > 0 or len(jobs) > 0:
             # Keep up to num_jobs jobs running
-            while len(jobs) < num_jobs and len(plant_files) > 0:
-                f = plant_files.pop()
+            while len(jobs) < num_jobs and len(model_files) > 0:
+                f = model_files.pop()
                 logger.debug("Parsing: %s" % f)
-                job = Popen([self.python, __file__, "-f", f, "-s", sdk_path, "-l", log_level, "parse_plant"],
+                job = Popen([self.python, __file__, "-f", f, "-s", sdk_path, "-l", log_level, "parse_model"],
                             stdout=PIPE)
                 jobs.append(job)
 
@@ -234,74 +234,74 @@ class ThicketDB:
             job = jobs.popleft()
             outs, errs = job.communicate()
             try:
-                p_rec = json.loads(outs)
-                self._db["plants"][p_rec["plant"]["name"]] = p_rec["plant"]
-                self.update_labels(p_rec["labels"])
-                logger.info('Added "%s"' % p_rec["plant"]["name"])
+                m_rec = json.loads(outs)
+                self._db["models"][m_rec["model"]["name"]] = m_rec["model"]
+                self.update_labels(m_rec["labels"])
+                logger.info('Added "%s"' % m_rec["model"]["name"])
             except json.decoder.JSONDecodeError as e:
                 logger.error("JSONDecodeError while parsing %s: %s" % (f, e))
 
-        if len(plant_files) > 0:
-            logger.error("Exited worker loop with %d plant files remaining" % len(plant_files))
+        if len(model_files) > 0:
+            logger.error("Exited worker loop with %d model files remaining" % len(model_files))
 
         if len(jobs) > 0:
             logger.error("Exited worker loop with %d jobs still running" % len(jobs))
 
         self.save()
-        logger.info("Processed %d/%d plants" % (self.plant_count(), num_plants))
+        logger.info("Processed %d/%d models" % (self.model_count(), num_models))
 
     def read(self):
         self.print_info()
 
-        for plant in self:
-            print("%s (%s)" % (plant.name, plant.label))
-            print("\tfile: %s" % plant.filepath)
-            print("\tmd5: %s" % plant.md5)
-            v = plant.get_variant()
+        for model in self:
+            print("%s (%s)" % (model.name, model.label))
+            print("\tfile: %s" % model.filepath)
+            print("\tmd5: %s" % model.md5)
+            v = model.get_variant()
             print("\tdefault_variant: %s (%s)" % (v.name, v.label))
             print("\tvariants:")
-            for v in plant.variants:
+            for v in model.variants:
                 print("\t\t%s (%s) %s" % (v.name, v.get_season().label,
                                           [s.name for s in v.seasons]))
 
     # Class methods
-    def parse_plant(filepath):
-        p = lbw.load(filepath)
-        p_rec = {}
+    def parse_model(filepath):
+        m = lbw.load(filepath)
+        m_rec = {}
 
-        plant = {}
-        plant["name"] = p.plant_meta["name"]
-        plant["filepath"] = filepath
-        plant["md5"] = md5sum(filepath)
-        plant["default_variant"] = p.default_model.name
-        preview_stem = p.plant_meta["botanical_name"].replace(" ", "_").replace(".", "")
+        model = {}
+        model["name"] = m.plant_meta["name"]
+        model["filepath"] = filepath
+        model["md5"] = md5sum(filepath)
+        model["default_variant"] = m.default_model.name
+        preview_stem = m.plant_meta["botanical_name"].replace(" ", "_").replace(".", "")
         preview_path = Path(filepath).parent.absolute() / (preview_stem + ".png")
         if not preview_path.is_file():
             logger.warning("Preview not found: %s" % preview_path)
             preview_path = ""
-        plant["preview"] = str(preview_path)
+        model["preview"] = str(preview_path)
 
         labels = {}
-        p_labels = {}
+        m_labels = {}
         # Store only the first label per locale
-        for label in p.plant_meta['labels']:
-            if not label['lang'] in p_labels:
-                p_labels[label['lang']] = label['text']
+        for label in m.plant_meta['labels']:
+            if not label['lang'] in m_labels:
+                m_labels[label['lang']] = label['text']
 
-        labels[p.name] = p_labels
+        labels[m.name] = m_labels
 
         variants = {}
         i = 0
         seasons = []
         s_labels = {}
-        for s in p.params[0]['enum']['options']:
+        for s in m.params[0]['enum']['options']:
             seasons.append(s['name'])
             s_labels[s['name']] = {}
             for s_lang in s['labels']:
                 s_labels[s['name']][s_lang['lang']] = s_lang['text']
-        default_season = p.params[0]['enum']['default']
+        default_season = m.params[0]['enum']['default']
 
-        for v in p.variants:
+        for v in m.variants:
             v_rec = {}
             labels.update(s_labels)
             v_rec["index"] = i
@@ -315,20 +315,20 @@ class ThicketDB:
             variants[v.name] = v_rec
             v_labels = {}
 
-            for label in next(x for x in p.params[1]['enum']['options'] if x['name'] == v.name)['labels']:
+            for label in next(x for x in m.params[1]['enum']['options'] if x['name'] == v.name)['labels']:
                 v_labels[label['lang']] = label['text']
             labels[v.name] = v_labels
 
             i = i + 1
-        plant["variants"] = variants
+        model["variants"] = variants
 
-        p_rec["plant"] = plant
-        p_rec["labels"] = labels
-        return p_rec
+        m_rec["model"] = model
+        m_rec["labels"] = labels
+        return m_rec
 
-    def parse_plant_json(filepath):
-        p_rec = ThicketDB.parse_plant(filepath)
-        print(json.dumps(p_rec))
+    def parse_model_json(filepath):
+        m_rec = ThicketDB.parse_model(filepath)
+        print(json.dumps(m_rec))
 
 
 def main():
@@ -338,16 +338,16 @@ def main():
 Thicket Database Tool
 Commands:
   read                read and print the db contents (requires -d)
-  build               scan plants path and add all plants to a new db (requires -d -p -s)
-  parse_plant         read a plant file and print the plant record json (requires -f -s)
+  build               scan models path and add all models to a new db (requires -d -p -s)
+  parse_model         read a model file and print the model record json (requires -f -s)
 '''))
 
-    argParse.add_argument("cmd", choices=["read", "build", "parse_plant"])
+    argParse.add_argument("cmd", choices=["read", "build", "parse_model"])
     argParse.add_argument("-d", help="database filename")
-    argParse.add_argument("-f", help="Laubwerk Plant filename (lbw.gz)")
+    argParse.add_argument("-f", help="Laubwerk Model filename (lbw.gz)")
     argParse.add_argument("-l", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
                           default="INFO", help="logger level")
-    argParse.add_argument("-p", help="Laubwerk Plants path")
+    argParse.add_argument("-p", help="Laubwerk Models path")
     argParse.add_argument("-s", help="Laubwerk Python SDK path")
 
     args = argParse.parse_args()
@@ -357,7 +357,7 @@ Commands:
 
     if args.s:
         # If the SDK path was specified, attempt to import the Laubwerk SDK The
-        # build and parse_plant commands require the Laubwerk SDK which may or
+        # build and parse_model commands require the Laubwerk SDK which may or
         # may not be in the sys.path depending on the OS, environment, and how
         # it was called (from Blender, as a subprocess, or via the command
         # line).
@@ -372,8 +372,8 @@ Commands:
     elif cmd == "build" and args.d and args.p and lbw:
         db = ThicketDB(args.d, create=True)
         db.build(args.p, args.s)
-    elif cmd == "parse_plant" and args.f and lbw:
-        ThicketDB.parse_plant_json(args.f)
+    elif cmd == "parse_model" and args.f and lbw:
+        ThicketDB.parse_model_json(args.f)
     else:
         argParse.print_help()
         return 1

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -284,21 +284,23 @@ class ThicketDB:
         labels = {}
         p_labels = {}
         # Store only the first label per locale
-        for label in p.labels.items():
-            p_labels[label[0]] = label[1][0]
+        for label in next(x for x in p.params[1]['enum']['options'] if x['name'] == p.name)['labels']:
+            p_labels[label['lang']] = label['text']
+
         labels[p.name] = p_labels
 
         models = {}
         i = 0
+        seasons = []
+        q_labels = {}
+        for q in p.params[0]['enum']['options']:
+            seasons.append(q['name'])
+            q_labels[q['name']] = {}
+            for q_lang in q['labels']:
+                q_labels[q['name']][q_lang['lang']] = q_lang['text']
+
         for m in p.models:
             m_rec = {}
-            seasons = []
-            q_labels = {}
-            for q in m.qualifiers:
-                seasons.append(q)
-                q_labels[q] = {}
-                for q_lang in m.qualifier_labels[q].items():
-                    q_labels[q][q_lang[0]] = q_lang[1][0]
             labels.update(q_labels)
             m_rec["index"] = i
             m_rec["qualifiers"] = seasons

--- a/thicket_db.py
+++ b/thicket_db.py
@@ -307,7 +307,7 @@ class ThicketDB:
             labels.update(q_labels)
             m_rec["index"] = i
             m_rec["qualifiers"] = seasons
-            m_rec["default_qualifier"] = default_season
+            m_rec["default_qualifier"] = seasons[default_season]
             preview_path = Path(filepath).parent.absolute() / "models" / (preview_stem + "_" + m.name + ".png")
             if not preview_path.is_file():
                 logger.warning("Preview not found: %s" % preview_path)

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -429,16 +429,16 @@ def lbw_to_bl_mat(plant, mat_id, mat_name, qualifier=None, proxy_color=None):
     return mat
 
 
-def import_lbw(filepath, model, viewport_lod, render_lod, mesh_args, obj_viewport=None, obj_render=None):
+def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewport=None, obj_render=None):
     time_main = time.time()
     lbw_plant = laubwerk.load(filepath)
     # TODO: This should be debug, but we cannot silence the SDK [debug] message
     # which appear without context without this appearing in the log first
     logger.info('Importing "%s"' % lbw_plant.name)
-    lbw_model = next((m for m in lbw_plant.models if m.name == model), lbw_plant.default_model)
-    if not lbw_model.name == model:
-        logger.warning("Model '%s' not found for '%s', using default model '%s'" %
-                       (model, lbw_plant.name, lbw_model.name))
+    lbw_variant = next((v for v in lbw_plant.variants if v.name == variant), lbw_plant.default_variant)
+    if not lbw_variant.name == variant:
+        logger.warning("Variant '%s' not found for '%s', using default variant '%s'" %
+                       (variant, lbw_plant.name, lbw_variant.name))
 
     # Create the viewport object (low detail)
     time_local = time.time()
@@ -448,7 +448,7 @@ def import_lbw(filepath, model, viewport_lod, render_lod, mesh_args, obj_viewpor
             obj_viewport.data.name = lbw_plant.name
             logger.debug("Reusing existing viewport object")
         elif viewport_lod == 'PROXY':
-            lbw_mesh = lbw_model.get_proxy()
+            lbw_mesh = lbw_variant.get_proxy()
             obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["qualifier"], True)
             logger.debug("Generated proxy viewport object in %.4fs" % (time.time() - time_local))
         elif viewport_lod == 'LOW':
@@ -463,7 +463,7 @@ def import_lbw(filepath, model, viewport_lod, render_lod, mesh_args, obj_viewpor
             vp_mesh_args["leaf_density"] = 0.5 * mesh_args["leaf_density"]
             vp_mesh_args["max_subdiv_level"] = 0
             logger.debug("viewport get_mesh(%s)" % str(vp_mesh_args))
-            lbw_mesh = lbw_model.get_mesh(**vp_mesh_args)
+            lbw_mesh = lbw_variant.get_mesh(**vp_mesh_args)
             obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["qualifier"], False)
             logger.debug("Generated low resolution viewport object in %.4fs" % (time.time() - time_local))
         else:
@@ -476,12 +476,12 @@ def import_lbw(filepath, model, viewport_lod, render_lod, mesh_args, obj_viewpor
         obj_render.data.name = lbw_plant.name + " (render)"
         logger.debug("Reusing existing render object")
     elif render_lod == 'PROXY':
-        lbw_mesh = lbw_model.get_proxy()
+        lbw_mesh = lbw_variant.get_proxy()
         obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["qualifier"], True)
         logger.debug("Generated proxy render object in %.4fs" % (time.time() - time_local))
     elif render_lod == 'FULL':
         logger.debug("render get_mesh(%s)" % str(mesh_args))
-        lbw_mesh = lbw_model.get_mesh(**mesh_args)
+        lbw_mesh = lbw_variant.get_mesh(**mesh_args)
         obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["qualifier"], False)
         logger.debug("Generated high resolution render object in %.4fs" % (time.time() - time_local))
     else:

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -79,9 +79,10 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
 
     # String operations are expensive, do them here outside the material loop
     wood_mat_name = lbw_plant.name + " wood"
-    wood_color = lbw_plant.get_wood_color()
+    # FIXME: fetch proper preview colors somehow
+    wood_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
     foliage_mat_name = lbw_plant.name + " foliage"
-    foliage_color = lbw_plant.get_foliage_color()
+    foliage_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
 
     use_1033 = False
     lbw_version = laubwerk.version_info
@@ -93,7 +94,7 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
     # read matids and materialnames and create and add materials to the laubwerktree
     materials = []
     i = 0
-    for matID in zip(lbw_mesh.matids):
+    for matID in zip(lbw_mesh.mat_idxs):
         mat_id = matID[0]
         lbw_mat = lbw_plant.materials[mat_id]
         mat_name = lbw_mat.name

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -36,6 +36,10 @@ VP_MIN_THICKNESS = 0.1
 NW = 300
 NH = 300
 
+MATERIAL_QUALITY_LOW = 0
+MATERIAL_QUALITY_MEDIUM = 1
+MATERIAL_QUALITY_HIGH = 2
+
 
 def new_collection(name, parent, singleton=False, exclude=False):
     if singleton and name in bpy.data.collections:
@@ -47,13 +51,8 @@ def new_collection(name, parent, singleton=False, exclude=False):
     return col
 
 
-def lbw_to_bl_obj(lbw_model, suffix, lbw_mesh, season, proxy):
+def lbw_to_bl_obj(lbw_materials, name, lbw_mesh, material_quality):
     """ Generate the Blender Object from the Laubwerk mesh and materials """
-
-    # construct object name
-    name = lbw_model.name
-    if suffix:
-        name += suffix
 
     # create mesh and object
     mesh = bpy.data.meshes.new(name)
@@ -77,175 +76,29 @@ def lbw_to_bl_obj(lbw_model, suffix, lbw_mesh, season, proxy):
     # Scale Laubwerk centimeters units to Blender meters units
     obj.data.transform(Matrix.Rotation(radians(90), 4, 'X') @ Matrix.Scale(.01, 4))
 
-    # String operations are expensive, do them here outside the material loop
-    wood_mat_name = lbw_model.name + " wood"
-    # FIXME: fetch proper preview colors somehow
-    wood_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
-    foliage_mat_name = lbw_model.name + " foliage"
-    foliage_color = (0.08423289656639099, 0.13307799398899078, 0.023182500153779984)
-
-    use_1033 = False
-    lbw_version = laubwerk.version_info
-    if lbw_version[0] <= 1:
-        if lbw_version[1] == 0:
-            if lbw_version[2] <= 33:
-                use_1033 = True
-
     # read matids and materialnames and create and add materials to the laubwerktree
     materials = []
     i = 0
     for matIdx in zip(lbw_mesh.mat_idxs):
         lbw_mat_idx = matIdx[0]
-        lbw_mat = lbw_model.materials[lbw_mat_idx]
-        mat_name = lbw_mat.name
-        proxy_color = None
-
-        if proxy:
-            if lbw_mat_idx == -1:
-                mat_name = foliage_mat_name
-                proxy_color = foliage_color
-            else:
-                mat_name = wood_mat_name
-                proxy_color = wood_color
+        lbw_mat = lbw_materials[lbw_mat_idx]
 
         if lbw_mat_idx not in materials:
             materials.append(lbw_mat_idx)
-            mat = bpy.data.materials.get(mat_name)
+            mat = bpy.data.materials.get(lbw_mat.name)
             if mat is None:
-                if use_1033:
-                    mat = lbw_to_bl_mat_1033(lbw_model, lbw_mat_idx, mat_name, season, proxy_color)
-                else:
-                    mat = lbw_to_bl_mat(lbw_model, lbw_mat_idx, mat_name, season, proxy_color)
+                mat = lbw_to_bl_mat(lbw_mat, material_quality)
             obj.data.materials.append(mat)
 
-        mat_index = obj.data.materials.find(mat_name)
+        mat_index = obj.data.materials.find(lbw_mat.name)
         if mat_index != -1:
             obj.data.polygons[i].material_index = mat_index
         else:
-            logger.warning("Material not found: %s" % mat_name)
+            logger.warning("Material not found: %s" % lbw_mat.name)
 
         i += 1
 
     return obj
-
-
-def lbw_to_bl_mat_1033(model, mat_idx, mat_name, season=None, proxy_color=None):
-    logger.warning("Laubwerk 1.0.33 support is deprecated and will be removed "
-                   "in future releases. Please upgrade to 1.0.34 or newer.")
-
-    global NW, NH
-
-    lbw_mat = model.materials[mat_idx]
-    mat = bpy.data.materials.new(mat_name)
-
-    mat.use_nodes = True
-    nodes = mat.node_tree.nodes
-    nodes.clear()
-    # create Principled BSDF node (primary multi-layer mixer node)
-    node_dif = nodes.new(type='ShaderNodeBsdfPrincipled')
-    node_dif.location = 2 * NW, 2 * NH
-    # create output node
-    node_out = nodes.new(type='ShaderNodeOutputMaterial')
-    node_out.location = 3 * NW, 2 * NH
-    # link nodes
-    links = mat.node_tree.links
-    links.new(node_dif.outputs[0], node_out.inputs[0])
-
-    mat.diffuse_color = proxy_color or lbw_mat.get_front().diffuse_color + (1.0,)
-    node_dif.inputs[0].default_value = mat.diffuse_color
-    if proxy_color:
-        return mat
-
-    # Diffuse Texture
-    logger.debug("Diffuse Texture: %s" % lbw_mat.get_front().diffuse_texture)
-    diffuse_path = lbw_mat.get_front().diffuse_texture
-    node_img = nodes.new(type='ShaderNodeTexImage')
-    node_img.location = 0, 2 * NH
-    node_img.image = bpy.data.images.load(diffuse_path)
-    links.new(node_img.outputs[0], node_dif.inputs[0])
-
-    # Handle Two-Sided Textures (diffuse texture only)
-    if lbw_mat.is_two_sided() and lbw_mat.sides_are_different():
-        logger.debug("Diffuse texture is two sided")
-        diffuse_back_path = lbw_mat.get_back().diffuse_texture
-        node_back_img = nodes.new(type='ShaderNodeTexImage')
-        node_back_img.location = -NW, 2 * NH
-        node_back_img.image = bpy.data.images.load(diffuse_back_path)
-        node_mix = nodes.new(type='ShaderNodeMixRGB')
-        node_mix.location = NW, 2 * NH
-        node_geometry = nodes.new(type='ShaderNodeNewGeometry')
-        node_geometry.location = -NW, NH
-        links.new(node_geometry.outputs[6], node_mix.inputs[0])
-        links.new(node_img.outputs[0], node_mix.inputs[1])
-        links.new(node_back_img.outputs[0], node_mix.inputs[2])
-        links.new(node_mix.outputs[0], node_dif.inputs[0])
-
-    # Alpha Texture
-    # Blender render engines support using the diffuse map alpha channel. We
-    # assume this rather than a separate alpha image.
-    alpha_path = lbw_mat.alpha_texture
-    logger.debug("Alpha Texture: %s" % lbw_mat.alpha_texture)
-    if alpha_path != "":
-        # Enable leaf clipping in Eevee
-        mat.blend_method = 'CLIP'
-        # TODO: mat.transparent_shadow_method = 'CLIP' ?
-
-        # All tested models either use the diffuse map for alpha or list a
-        # different texture for alpha in error (wrong diffuse map as opposed a
-        # separate alpha map). Ignore the difference if it exists, assume alpha
-        # comes from diffuse, and issue a warning when the difference appears.
-        links.new(node_img.outputs['Alpha'], node_dif.inputs['Alpha'])
-        if alpha_path != diffuse_path:
-            # NOTE: This affects at least 'Howea forsteriana'
-            logger.warning("Alpha Texture differs from diffuse image path:")
-            logger.warning("Alpha Texture: %s" % lbw_mat.alpha_texture)
-            logger.warning("Diffuse Texture: %s" % lbw_mat.get_front().diffuse_texture)
-
-    # Subsurface Texture
-    sub_path = lbw_mat.subsurface_texture
-    if sub_path != "":
-        logger.debug("Subsurface Texture: %s" % lbw_mat.subsurface_texture)
-        node_sub = nodes.new(type='ShaderNodeTexImage')
-        node_sub.location = 0, NH
-        node_sub.image = bpy.data.images.load(sub_path)
-
-        # Laubwerk models only support subsurface as a translucency effect for
-        # thin-shell material, indicated by having two sides:
-        if lbw_mat.is_two_sided():
-            node_sub.image.colorspace_settings.is_data = True
-            links.new(node_sub.outputs['Color'], node_dif.inputs['Transmission'])
-        else:
-            logger.warning("Subsurface Depth > 0. Not supported.")
-
-    # Index of Refraction (IOR)
-    # All Laubwerk Materials default to 1.33 across host applications
-    node_dif.inputs['IOR'].default_value = 1.33
-
-    # Bump Texture
-    bump_path = lbw_mat.get_front().bump_texture
-    if bump_path != "":
-        logger.debug("Bump Texture: %s" % lbw_mat.get_front().bump_texture)
-        node_bumpimg = nodes.new(type='ShaderNodeTexImage')
-        node_bumpimg.location = 0, 0
-        node_bumpimg.image = bpy.data.images.load(bump_path)
-        node_bumpimg.image.colorspace_settings.is_data = True
-        node_bump = nodes.new(type='ShaderNodeBump')
-        node_bump.location = NW, 0
-        # TODO: Make the Distance configurable to tune for each render engine
-        logger.debug("Bump Strength: %f" % lbw_mat.get_front().bump_strength)
-        node_bump.inputs['Strength'].default_value = lbw_mat.get_front().bump_strength
-        node_bump.inputs['Distance'].default_value = 0.02
-        links.new(node_bumpimg.outputs['Color'], node_bump.inputs['Height'])
-        links.new(node_bump.outputs['Normal'], node_dif.inputs['Normal'])
-
-    if lbw_mat.displacement_texture:
-        logger.debug("Displacement Texture: %s" % lbw_mat.displacement_texture)
-    if lbw_mat.get_front().normal_texture:
-        logger.debug("Normal Texture: %s" % lbw_mat.get_front().normal_texture)
-    if lbw_mat.get_front().specular_texture:
-        logger.debug("Specular Texture: %s" % lbw_mat.get_front().specular_texture)
-
-    return mat
 
 
 def lbw_side_to_bsdf(mat, side, x=0, y=0):
@@ -260,12 +113,15 @@ def lbw_side_to_bsdf(mat, side, x=0, y=0):
     node_bsdf.inputs['IOR'].default_value = 1.33
 
     # Diffuse Texture
-    logger.debug("Diffuse Texture: %s" % side.base_color_texture)
-    base_path = side.base_color_texture
-    node_img = nodes.new(type='ShaderNodeTexImage')
-    node_img.location = x, y + NH
-    node_img.image = bpy.data.images.load(base_path)
-    links.new(node_img.outputs[0], node_bsdf.inputs[0])
+    if side.base_color_texture:
+        logger.debug("Diffuse Texture: %s" % side.base_color_texture)
+        base_path = side.base_color_texture
+        node_img = nodes.new(type='ShaderNodeTexImage')
+        node_img.location = x, y + NH
+        node_img.image = bpy.data.images.load(base_path)
+        links.new(node_img.outputs[0], node_bsdf.inputs[0])
+    else:
+        node_bsdf.inputs[0].default_value = side.base_color + (1.0,)
 
     # Bump Texture
     bump_path = side.bump_texture
@@ -301,17 +157,19 @@ def lbw_side_to_bsdf(mat, side, x=0, y=0):
     return node_bsdf
 
 
-def lbw_to_bl_mat(model, mat_idx, mat_name, season=None, proxy_color=None):
+def lbw_to_bl_mat(lbw_mat, material_quality):
+    """Convert Laubwerk Material to Blender material"""
     global NW, NH
 
-    lbw_mat = model.materials[mat_idx]
-    mat = bpy.data.materials.new(mat_name)
-
-    if proxy_color:
-        mat.diffuse_color = proxy_color
-        return mat
+    mat = bpy.data.materials.new(lbw_mat.name)
 
     mat.diffuse_color = lbw_mat.get_front().base_color + (1.0,)
+
+    # Low quality materials only get a diffuse color and nothing else, so we
+    # can exit early
+    if material_quality == MATERIAL_QUALITY_LOW:
+        return mat
+
     mat.use_nodes = True
 
     nodes = mat.node_tree.nodes
@@ -429,16 +287,16 @@ def lbw_to_bl_mat(model, mat_idx, mat_name, season=None, proxy_color=None):
     return mat
 
 
-def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewport=None, obj_render=None):
+def import_lbw(filepath, viewport_lod, render_lod, mesh_args, obj_viewport=None, obj_render=None):
     time_main = time.time()
     lbw_model = laubwerk.load(filepath)
     # TODO: This should be debug, but we cannot silence the SDK [debug] message
     # which appear without context without this appearing in the log first
     logger.info('Importing "%s"' % lbw_model.name)
-    lbw_variant = next((v for v in lbw_model.variants if v.name == variant), lbw_model.default_variant)
-    if not lbw_variant.name == variant:
+    lbw_variant = next((v for v in lbw_model.variants if v.name == mesh_args["variant"]), lbw_model.default_variant)
+    if not lbw_variant.name == mesh_args["variant"]:
         logger.warning("Variant '%s' not found for '%s', using default variant '%s'" %
-                       (variant, lbw_model.name, lbw_variant.name))
+                       (mesh_args["variant"], lbw_model.name, lbw_variant.name))
 
     # Create the viewport object (low detail)
     time_local = time.time()
@@ -448,8 +306,10 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
             obj_viewport.data.name = lbw_model.name
             logger.debug("Reusing existing viewport object")
         elif viewport_lod == 'PROXY':
-            lbw_mesh = lbw_variant.get_proxy()
-            obj_viewport = lbw_to_bl_obj(lbw_model, None, lbw_mesh, mesh_args["season"], True)
+            lbw_mesh, lbw_materials = lbw_model.get_proxy({"variant": mesh_args["variant"],
+                                                           "season": mesh_args["season"]},
+                                                          True)
+            obj_viewport = lbw_to_bl_obj(lbw_materials, lbw_model.name, lbw_mesh, MATERIAL_QUALITY_LOW)
             logger.debug("Generated proxy viewport object in %.4fs" % (time.time() - time_local))
         elif viewport_lod == 'LOW':
             vp_mesh_args = mesh_args.copy()
@@ -466,7 +326,7 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
             vp_mesh_args["qualifier"] = mesh_args["season"]  # FIXME: qualifier still used in Laubwerk API
             lbw_mesh = lbw_variant.get_mesh(**vp_mesh_args)
             del vp_mesh_args["qualifier"]
-            obj_viewport = lbw_to_bl_obj(lbw_model, None, lbw_mesh, mesh_args["season"], False)
+            obj_viewport = lbw_to_bl_obj(lbw_model.materials, lbw_model.name, lbw_mesh, MATERIAL_QUALITY_HIGH)
             logger.debug("Generated low resolution viewport object in %.4fs" % (time.time() - time_local))
         else:
             logger.warning("Unknown viewport_lod: %s" % viewport_lod)
@@ -478,15 +338,17 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
         obj_render.data.name = lbw_model.name + " (render)"
         logger.debug("Reusing existing render object")
     elif render_lod == 'PROXY':
-        lbw_mesh = lbw_variant.get_proxy()
-        obj_render = lbw_to_bl_obj(lbw_model, " (render)", lbw_mesh, mesh_args["season"], True)
+        lbw_mesh, lbw_materials = lbw_model.get_proxy({"variant": mesh_args["variant"],
+                                                       "season": mesh_args["season"]},
+                                                      True)
+        obj_render = lbw_to_bl_obj(lbw_materials, lbw_model.name + " (render)", lbw_mesh, MATERIAL_QUALITY_LOW)
         logger.debug("Generated proxy render object in %.4fs" % (time.time() - time_local))
     elif render_lod == 'FULL':
         logger.debug("render get_mesh(%s)" % str(mesh_args))
         mesh_args["qualifier"] = mesh_args["season"]  # FIXME: qualifier still used in Laubwerk API
         lbw_mesh = lbw_variant.get_mesh(**mesh_args)
         del mesh_args["qualifier"]
-        obj_render = lbw_to_bl_obj(lbw_model, " (render)", lbw_mesh, mesh_args["season"], False)
+        obj_render = lbw_to_bl_obj(lbw_model.materials, lbw_model.name + " (render)", lbw_mesh, MATERIAL_QUALITY_HIGH)
         logger.debug("Generated high resolution render object in %.4fs" % (time.time() - time_local))
     else:
         logger.warning("Unknown render_lod: %s" % render_lod)

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -463,7 +463,9 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
             vp_mesh_args["leaf_density"] = 0.5 * mesh_args["leaf_density"]
             vp_mesh_args["max_subdiv_level"] = 0
             logger.debug("viewport get_mesh(%s)" % str(vp_mesh_args))
+            vp_mesh_args["qualifier"] = mesh_args["season"]  # FIXME: qualifier still used in Laubwerk API
             lbw_mesh = lbw_variant.get_mesh(**vp_mesh_args)
+            del vp_mesh_args["qualifier"]
             obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["season"], False)
             logger.debug("Generated low resolution viewport object in %.4fs" % (time.time() - time_local))
         else:
@@ -481,7 +483,9 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
         logger.debug("Generated proxy render object in %.4fs" % (time.time() - time_local))
     elif render_lod == 'FULL':
         logger.debug("render get_mesh(%s)" % str(mesh_args))
+        mesh_args["qualifier"] = mesh_args["season"]  # FIXME: qualifier still used in Laubwerk API
         lbw_mesh = lbw_variant.get_mesh(**mesh_args)
+        del mesh_args["qualifier"]
         obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["season"], False)
         logger.debug("Generated high resolution render object in %.4fs" % (time.time() - time_local))
     else:

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -47,7 +47,7 @@ def new_collection(name, parent, singleton=False, exclude=False):
     return col
 
 
-def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
+def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, season, proxy):
     """ Generate the Blender Object from the Laubwerk mesh and materials """
 
     # construct object name
@@ -113,9 +113,9 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
             mat = bpy.data.materials.get(mat_name)
             if mat is None:
                 if use_1033:
-                    mat = lbw_to_bl_mat_1033(lbw_plant, mat_id, mat_name, qualifier, proxy_color)
+                    mat = lbw_to_bl_mat_1033(lbw_plant, mat_id, mat_name, season, proxy_color)
                 else:
-                    mat = lbw_to_bl_mat(lbw_plant, mat_id, mat_name, qualifier, proxy_color)
+                    mat = lbw_to_bl_mat(lbw_plant, mat_id, mat_name, season, proxy_color)
             obj.data.materials.append(mat)
 
         mat_index = obj.data.materials.find(mat_name)
@@ -129,7 +129,7 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, qualifier, proxy):
     return obj
 
 
-def lbw_to_bl_mat_1033(plant, mat_id, mat_name, qualifier=None, proxy_color=None):
+def lbw_to_bl_mat_1033(plant, mat_id, mat_name, season=None, proxy_color=None):
     logger.warning("Laubwerk 1.0.33 support is deprecated and will be removed "
                    "in future releases. Please upgrade to 1.0.34 or newer.")
 
@@ -301,7 +301,7 @@ def lbw_side_to_bsdf(mat, side, x=0, y=0):
     return node_bsdf
 
 
-def lbw_to_bl_mat(plant, mat_id, mat_name, qualifier=None, proxy_color=None):
+def lbw_to_bl_mat(plant, mat_id, mat_name, season=None, proxy_color=None):
     global NW, NH
 
     lbw_mat = plant.materials[mat_id]
@@ -449,7 +449,7 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
             logger.debug("Reusing existing viewport object")
         elif viewport_lod == 'PROXY':
             lbw_mesh = lbw_variant.get_proxy()
-            obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["qualifier"], True)
+            obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["season"], True)
             logger.debug("Generated proxy viewport object in %.4fs" % (time.time() - time_local))
         elif viewport_lod == 'LOW':
             vp_mesh_args = mesh_args.copy()
@@ -464,7 +464,7 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
             vp_mesh_args["max_subdiv_level"] = 0
             logger.debug("viewport get_mesh(%s)" % str(vp_mesh_args))
             lbw_mesh = lbw_variant.get_mesh(**vp_mesh_args)
-            obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["qualifier"], False)
+            obj_viewport = lbw_to_bl_obj(lbw_plant, None, lbw_mesh, mesh_args["season"], False)
             logger.debug("Generated low resolution viewport object in %.4fs" % (time.time() - time_local))
         else:
             logger.warning("Unknown viewport_lod: %s" % viewport_lod)
@@ -477,12 +477,12 @@ def import_lbw(filepath, variant, viewport_lod, render_lod, mesh_args, obj_viewp
         logger.debug("Reusing existing render object")
     elif render_lod == 'PROXY':
         lbw_mesh = lbw_variant.get_proxy()
-        obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["qualifier"], True)
+        obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["season"], True)
         logger.debug("Generated proxy render object in %.4fs" % (time.time() - time_local))
     elif render_lod == 'FULL':
         logger.debug("render get_mesh(%s)" % str(mesh_args))
         lbw_mesh = lbw_variant.get_mesh(**mesh_args)
-        obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["qualifier"], False)
+        obj_render = lbw_to_bl_obj(lbw_plant, " (render)", lbw_mesh, mesh_args["season"], False)
         logger.debug("Generated high resolution render object in %.4fs" % (time.time() - time_local))
     else:
         logger.warning("Unknown render_lod: %s" % render_lod)

--- a/thicket_lbw.py
+++ b/thicket_lbw.py
@@ -94,28 +94,28 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, season, proxy):
     # read matids and materialnames and create and add materials to the laubwerktree
     materials = []
     i = 0
-    for matID in zip(lbw_mesh.mat_idxs):
-        mat_id = matID[0]
-        lbw_mat = lbw_plant.materials[mat_id]
+    for matIdx in zip(lbw_mesh.mat_idxs):
+        lbw_mat_idx = matIdx[0]
+        lbw_mat = lbw_plant.materials[lbw_mat_idx]
         mat_name = lbw_mat.name
         proxy_color = None
 
         if proxy:
-            if mat_id == -1:
+            if lbw_mat_idx == -1:
                 mat_name = foliage_mat_name
                 proxy_color = foliage_color
             else:
                 mat_name = wood_mat_name
                 proxy_color = wood_color
 
-        if mat_id not in materials:
-            materials.append(mat_id)
+        if lbw_mat_idx not in materials:
+            materials.append(lbw_mat_idx)
             mat = bpy.data.materials.get(mat_name)
             if mat is None:
                 if use_1033:
-                    mat = lbw_to_bl_mat_1033(lbw_plant, mat_id, mat_name, season, proxy_color)
+                    mat = lbw_to_bl_mat_1033(lbw_plant, lbw_mat_idx, mat_name, season, proxy_color)
                 else:
-                    mat = lbw_to_bl_mat(lbw_plant, mat_id, mat_name, season, proxy_color)
+                    mat = lbw_to_bl_mat(lbw_plant, lbw_mat_idx, mat_name, season, proxy_color)
             obj.data.materials.append(mat)
 
         mat_index = obj.data.materials.find(mat_name)
@@ -129,13 +129,13 @@ def lbw_to_bl_obj(lbw_plant, suffix, lbw_mesh, season, proxy):
     return obj
 
 
-def lbw_to_bl_mat_1033(plant, mat_id, mat_name, season=None, proxy_color=None):
+def lbw_to_bl_mat_1033(plant, mat_idx, mat_name, season=None, proxy_color=None):
     logger.warning("Laubwerk 1.0.33 support is deprecated and will be removed "
                    "in future releases. Please upgrade to 1.0.34 or newer.")
 
     global NW, NH
 
-    lbw_mat = plant.materials[mat_id]
+    lbw_mat = plant.materials[mat_idx]
     mat = bpy.data.materials.new(mat_name)
 
     mat.use_nodes = True
@@ -301,10 +301,10 @@ def lbw_side_to_bsdf(mat, side, x=0, y=0):
     return node_bsdf
 
 
-def lbw_to_bl_mat(plant, mat_id, mat_name, season=None, proxy_color=None):
+def lbw_to_bl_mat(plant, mat_idx, mat_name, season=None, proxy_color=None):
     global NW, NH
 
-    lbw_mat = plant.materials[mat_id]
+    lbw_mat = plant.materials[mat_idx]
     mat = bpy.data.materials.new(mat_name)
 
     if proxy_color:


### PR DESCRIPTION
Laubwerk updated their API to support python 3.10/3.11 some time ago. This PR adapts to that and updates a lot of code to make every feature work with the new Blender versions.